### PR TITLE
feat: 다각형 복수 선택, restore 페이지에서는 패키지 파일 업로드 하도록 변경, 로컬 서버 환경과 연결 테스트 완료

### DIFF
--- a/app/downscale/page.tsx
+++ b/app/downscale/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ArrowLeft, Download, Loader2 } from "lucide-react"
 import FileUpload from "@/components/file-upload"
 import PolygonDrawer from "@/components/polygon-drawer"
@@ -16,41 +17,59 @@ export default function DownscalePage() {
   const router = useRouter()
   const [uploadedFile, setUploadedFile] = useState<File | null>(null)
   const [imageUrl, setImageUrl] = useState<string | null>(null)
-  const [polygonPoints, setPolygonPoints] = useState<Point[]>([])
+  const [polygons, setPolygons] = useState<Point[][]>([])
+  const [scaler, setScaler] = useState<number>(2)
   const [isProcessing, setIsProcessing] = useState(false)
   const [resultUrl, setResultUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
 
   const handleFileSelect = (file: File) => {
     setUploadedFile(file)
     const url = URL.createObjectURL(file)
     setImageUrl(url)
-    setPolygonPoints([])
+    setPolygons([])
     setResultUrl(null)
+    setError(null)
   }
 
-  const handlePolygonComplete = (points: Point[]) => {
-    setPolygonPoints(points)
+  const handlePolygonsComplete = (newPolygons: Point[][]) => {
+    setPolygons(newPolygons)
   }
 
   const handleDownscale = async () => {
-    if (!uploadedFile || polygonPoints.length === 0) return
+    if (!uploadedFile || polygons.length === 0) return
 
     setIsProcessing(true)
+    setError(null)
 
     try {
-      // Simulate API call to desktop service
       const formData = new FormData()
       formData.append("image", uploadedFile)
-      formData.append("polygon", JSON.stringify(polygonPoints))
+      formData.append(
+        "polygons",
+        JSON.stringify(
+          polygons.map(poly => poly.map(pt => [Math.round(pt.x), Math.round(pt.y)]))
+        )
+      )
+      formData.append("scaler", scaler.toString())
 
-      // Simulate processing time
-      await new Promise((resolve) => setTimeout(resolve, 3000))
+      const response = await fetch("http://localhost:8000/compress", {
+        method: "POST",
+        body: formData,
+      })
 
-      // For demo purposes, we'll use the original image as result
-      // In real implementation, this would be the processed image from the API
-      setResultUrl(imageUrl)
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.detail || "압축 처리 중 오류가 발생했습니다.")
+      }
+
+      // .pkg 파일을 blob으로 받기
+      const blob = await response.blob()
+      const url = URL.createObjectURL(blob)
+      setResultUrl(url)
     } catch (error) {
       console.error("Error processing image:", error)
+      setError(error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.")
     } finally {
       setIsProcessing(false)
     }
@@ -61,7 +80,7 @@ export default function DownscalePage() {
 
     const link = document.createElement("a")
     link.href = resultUrl
-    link.download = "downscaled-image.png"
+    link.download = "compressed-output.pkg"
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
@@ -73,9 +92,9 @@ export default function DownscalePage() {
         <div className="flex items-center gap-4 mb-8">
           <Button onClick={() => router.push("/")} variant="outline" size="sm">
             <ArrowLeft className="h-4 w-4 mr-2" />
-            Back to Home
+            홈으로 돌아가기
           </Button>
-          <h1 className="text-3xl font-bold text-gray-900">Downscale Image</h1>
+          <h1 className="text-3xl font-bold text-gray-900">이미지 압축</h1>
         </div>
 
         {!imageUrl ? (
@@ -83,41 +102,71 @@ export default function DownscalePage() {
         ) : (
           <div className="space-y-6">
             <div className="bg-white rounded-lg p-6 shadow-sm">
-              <h2 className="text-xl font-semibold mb-4">Draw Selection Polygon</h2>
-              <PolygonDrawer imageUrl={imageUrl} onPolygonComplete={handlePolygonComplete} />
+              <h2 className="text-xl font-semibold mb-4">다각형 영역 선택</h2>
+              <PolygonDrawer imageUrl={imageUrl} onPolygonComplete={handlePolygonsComplete} />
             </div>
 
-            {polygonPoints.length > 0 && (
-              <div className="flex justify-center">
-                <Button onClick={handleDownscale} disabled={isProcessing} size="lg" className="px-8">
-                  {isProcessing ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Processing...
-                    </>
-                  ) : (
-                    "Downscale"
-                  )}
-                </Button>
+            {polygons.length > 0 && (
+              <div className="bg-white rounded-lg p-6 shadow-sm">
+                <h2 className="text-xl font-semibold mb-4">압축 설정</h2>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                      다운스케일 배율
+                    </label>
+                    <Select value={scaler.toString()} onValueChange={(value) => setScaler(parseInt(value))}>
+                      <SelectTrigger className="w-48">
+                        <SelectValue placeholder="배율 선택" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="2">2배</SelectItem>
+                        <SelectItem value="3">3배</SelectItem>
+                        <SelectItem value="4">4배</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  
+                  <div className="flex justify-center">
+                    <Button onClick={handleDownscale} disabled={isProcessing} size="lg" className="px-8">
+                      {isProcessing ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          압축 중...
+                        </>
+                      ) : (
+                        "이미지 압축"
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                <p className="text-red-700 text-sm">{error}</p>
               </div>
             )}
 
             {resultUrl && (
               <div className="bg-white rounded-lg p-6 shadow-sm">
-                <h2 className="text-xl font-semibold mb-4">Result</h2>
+                <h2 className="text-xl font-semibold mb-4">압축 결과</h2>
                 <div className="space-y-4">
-                  <div className="flex justify-center">
-                    <img
-                      src={resultUrl || "/placeholder.svg"}
-                      alt="Processed result"
-                      className="max-w-full h-auto rounded border"
-                      style={{ maxHeight: "600px" }}
-                    />
+                  <div className="text-center p-8 border-2 border-dashed border-gray-300 rounded-lg">
+                    <div className="text-gray-600 mb-4">
+                      <svg className="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+                        <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </div>
+                    <p className="text-lg font-medium text-gray-900">압축 완료!</p>
+                    <p className="text-sm text-gray-500">
+                      {polygons.length}개의 다각형 영역이 {scaler}배 다운스케일로 압축되었습니다.
+                    </p>
                   </div>
                   <div className="flex justify-center">
                     <Button onClick={handleDownload}>
                       <Download className="h-4 w-4 mr-2" />
-                      Download Result
+                      압축 파일 다운로드 (.pkg)
                     </Button>
                   </div>
                 </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import NextImage from "next/image"
+import { Camera, RotateCcw } from "lucide-react"
 
 export default function LandingPage() {
   const [blurLevel, setBlurLevel] = useState(4)
@@ -16,7 +17,6 @@ export default function LandingPage() {
     img.onload = () => setBackgroundLoaded(true)
     img.src = "/20230823_185401_1.jpg"  
   }, [])
-
 
   const handleDownscale = () => {
     router.push("/downscale")
@@ -55,19 +55,28 @@ export default function LandingPage() {
       {!backgroundLoaded && <div className="absolute inset-0 bg-gradient-to-br from-blue-400 to-green-400" />}
 
       {/* Dark Overlay */}
-      <div className="absolute inset-0 bg-black/30" />
+      <div className="absolute inset-0 bg-black/40" />
 
-      {/* Chewy Dipps Image Overlay - Always Clear */}
-      <div className="absolute inset-0 flex items-center justify-center">
-        <div className="relative z-10">
-          <NextImage
-            src="/chewy-dipps.png"
-            alt="Chewy Dipps"
-            width={400}
-            height={400}
-            className="drop-shadow-2xl"
-            priority
-          />
+      {/* Main Content */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center text-white">
+        <div className="text-center mb-16">
+          <h1 className="text-6xl font-bold mb-4 drop-shadow-lg">MRS3</h1>
+          <p className="text-xl font-medium drop-shadow-md mb-2">다각형 영역 기반 이미지 압축 시스템</p>
+          <p className="text-lg opacity-90 drop-shadow-md">Multi-Region Selective Super-resolution System</p>
+        </div>
+
+        {/* Feature Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
+          <div className="bg-white/10 backdrop-blur-sm rounded-lg p-6 border border-white/20">
+            <Camera className="h-8 w-8 mb-4 text-blue-300" />
+            <h3 className="text-xl font-semibold mb-2">이미지 압축</h3>
+            <p className="text-sm opacity-90">다각형 영역을 선택하여 스마트한 이미지 압축을 수행합니다.</p>
+          </div>
+          <div className="bg-white/10 backdrop-blur-sm rounded-lg p-6 border border-white/20">
+            <RotateCcw className="h-8 w-8 mb-4 text-green-300" />
+            <h3 className="text-xl font-semibold mb-2">이미지 복원</h3>
+            <p className="text-sm opacity-90">AI 기반 EDSR 또는 OpenCV로 고품질 이미지 복원을 제공합니다.</p>
+          </div>
         </div>
       </div>
 
@@ -78,9 +87,10 @@ export default function LandingPage() {
           onMouseEnter={handleDownscaleHover}
           onMouseLeave={handleMouseLeave}
           size="lg"
-          className="px-8 py-4 text-lg font-semibold bg-blue-600 hover:bg-blue-700 transition-all duration-200"
+          className="px-8 py-4 text-lg font-semibold bg-blue-600 hover:bg-blue-700 transition-all duration-200 shadow-lg"
         >
-          Downscale
+          <Camera className="h-5 w-5 mr-2" />
+          이미지 압축
         </Button>
         <Button
           onClick={handleRestore}
@@ -88,9 +98,10 @@ export default function LandingPage() {
           onMouseLeave={handleMouseLeave}
           size="lg"
           variant="outline"
-          className="px-8 py-4 text-lg font-semibold bg-white/90 hover:bg-white transition-all duration-200"
+          className="px-8 py-4 text-lg font-semibold bg-white/90 hover:bg-white transition-all duration-200 shadow-lg border-2"
         >
-          Restore
+          <RotateCcw className="h-5 w-5 mr-2" />
+          이미지 복원
         </Button>
       </div>
     </div>

--- a/app/restore/page.tsx
+++ b/app/restore/page.tsx
@@ -3,41 +3,56 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { ArrowLeft, Download, Loader2 } from "lucide-react"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { ArrowLeft, Download, Loader2, Upload } from "lucide-react"
 import FileUpload from "@/components/file-upload"
 
 export default function RestorePage() {
   const router = useRouter()
   const [uploadedFile, setUploadedFile] = useState<File | null>(null)
-  const [imageUrl, setImageUrl] = useState<string | null>(null)
+  const [mrs3Mode, setMrs3Mode] = useState<number>(-1)
   const [isProcessing, setIsProcessing] = useState(false)
   const [resultUrl, setResultUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
 
   const handleFileSelect = (file: File) => {
-    setUploadedFile(file)
-    const url = URL.createObjectURL(file)
-    setImageUrl(url)
-    setResultUrl(null)
+    if (file && file.name.endsWith('.pkg')) {
+      setUploadedFile(file)
+      setResultUrl(null)
+      setError(null)
+    } else {
+      setError('pkg 파일만 업로드 가능합니다.')
+    }
   }
 
   const handleRestore = async () => {
     if (!uploadedFile) return
 
     setIsProcessing(true)
+    setError(null)
 
     try {
-      // Simulate API call to desktop service
       const formData = new FormData()
-      formData.append("image", uploadedFile)
+      formData.append("pkg", uploadedFile)
+      formData.append("mrs3_mode", mrs3Mode.toString())
 
-      // Simulate processing time
-      await new Promise((resolve) => setTimeout(resolve, 2500))
+      const response = await fetch("http://localhost:8000/restore", {
+        method: "POST",
+        body: formData,
+      })
 
-      // For demo purposes, we'll use the original image as result
-      // In real implementation, this would be the restored image from the API
-      setResultUrl(imageUrl)
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.detail || "복원 처리 중 오류가 발생했습니다.")
+      }
+
+      // 복원된 이미지를 blob으로 받기
+      const blob = await response.blob()
+      const url = URL.createObjectURL(blob)
+      setResultUrl(url)
     } catch (error) {
-      console.error("Error processing image:", error)
+      console.error("Error processing pkg file:", error)
+      setError(error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.")
     } finally {
       setIsProcessing(false)
     }
@@ -54,69 +69,105 @@ export default function RestorePage() {
     document.body.removeChild(link)
   }
 
-  return (
+   return (
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="container mx-auto px-4 max-w-4xl">
         <div className="flex items-center gap-4 mb-8">
           <Button onClick={() => router.push("/")} variant="outline" size="sm">
             <ArrowLeft className="h-4 w-4 mr-2" />
-            Back to Home
+            홈으로 돌아가기
           </Button>
-          <h1 className="text-3xl font-bold text-gray-900">Restore Image</h1>
+          <h1 className="text-3xl font-bold text-gray-900">이미지 복원</h1>
         </div>
 
-        {!imageUrl ? (
-          <FileUpload onFileSelect={handleFileSelect} />
-        ) : (
-          <div className="space-y-6">
-            <div className="bg-white rounded-lg p-6 shadow-sm">
-              <h2 className="text-xl font-semibold mb-4">Original Image</h2>
-              <div className="flex justify-center">
-                <img
-                  src={imageUrl || "/placeholder.svg"}
-                  alt="Uploaded image"
-                  className="max-w-full h-auto rounded border"
-                  style={{ maxHeight: "600px" }}
-                />
+        <div className="space-y-6">
+          {/* PKG 파일 업로드 */}
+          <div className="bg-white rounded-lg p-6 shadow-sm">
+            <h2 className="text-xl font-semibold mb-4">PKG 파일 업로드</h2>
+            <FileUpload
+              onFileSelect={handleFileSelect}
+              accept=".pkg"
+              maxSize={10 * 1024 * 1024}
+            />
+            {uploadedFile && (
+              <div className="mt-4 p-3 bg-green-50 border border-green-200 rounded-md">
+                <p className="text-sm text-green-700">
+                  선택된 파일: {uploadedFile.name}
+                </p>
               </div>
-            </div>
-
-            <div className="flex justify-center">
-              <Button onClick={handleRestore} disabled={isProcessing} size="lg" className="px-8">
-                {isProcessing ? (
-                  <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    Restoring...
-                  </>
-                ) : (
-                  "Restore"
-                )}
-              </Button>
-            </div>
-
-            {resultUrl && (
-              <div className="bg-white rounded-lg p-6 shadow-sm">
-                <h2 className="text-xl font-semibold mb-4">Restored Result</h2>
-                <div className="space-y-4">
-                  <div className="flex justify-center">
-                    <img
-                      src={resultUrl || "/placeholder.svg"}
-                      alt="Restored result"
-                      className="max-w-full h-auto rounded border"
-                      style={{ maxHeight: "600px" }}
-                    />
-                  </div>
-                  <div className="flex justify-center">
-                    <Button onClick={handleDownload}>
-                      <Download className="h-4 w-4 mr-2" />
-                      Download Result
-                    </Button>
-                  </div>
-                </div>
+            )}
+            {error && (
+              <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-md">
+                <p className="text-sm text-red-700">{error}</p>
               </div>
             )}
           </div>
-        )}
+
+          {/* 복원 설정 */}
+          {uploadedFile && (
+            <div className="bg-white rounded-lg p-6 shadow-sm">
+              <h2 className="text-xl font-semibold mb-4">복원 설정</h2>
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    업스케일 방식
+                  </label>
+                  <Select value={mrs3Mode.toString()} onValueChange={(value) => setMrs3Mode(parseInt(value))}>
+                    <SelectTrigger className="w-64">
+                      <SelectValue placeholder="업스케일 방식 선택" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="-1">EDSR (고품질 AI 업스케일)</SelectItem>
+                      <SelectItem value="0">OpenCV</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-gray-500 mt-1">
+                    EDSR은 AI 기반 고품질 업스케일링이지만 처리 시간이 오래 걸릴 수 있습니다.
+                  </p>
+                </div>
+                
+                <div className="flex justify-center">
+                  <Button onClick={handleRestore} disabled={isProcessing} size="lg" className="px-8">
+                    {isProcessing ? (
+                      <>
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        복원 중...
+                      </>
+                    ) : (
+                      "이미지 복원"
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* 복원 결과 */}
+          {resultUrl && (
+            <div className="bg-white rounded-lg p-6 shadow-sm">
+              <h2 className="text-xl font-semibold mb-4">복원 결과</h2>
+              <div className="space-y-4">
+                <div className="flex justify-center">
+                  <img
+                    src={resultUrl}
+                    alt="복원된 이미지"
+                    className="max-w-full h-auto rounded border"
+                    style={{ maxHeight: "600px" }}
+                  />
+                </div>
+                <div className="text-center">
+                  <p className="text-sm text-gray-600 mb-4">
+                    {mrs3Mode === -1 ? 'EDSR AI 업스케일링' : `OpenCV 방식 (모드 ${mrs3Mode})`}으로 복원된 이미지입니다.
+                  </p>
+                  <Button onClick={handleDownload}>
+                    <Download className="h-4 w-4 mr-2" />
+                    복원 이미지 다운로드
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -9,9 +9,17 @@ interface FileUploadProps {
   onFileSelect: (file: File) => void
   accept?: string
   maxSize?: number
+  buttonText?: string
+  description?: string
 }
 
-export default function FileUpload({ onFileSelect, accept = "image/*", maxSize = 10 * 1024 * 1024 }: FileUploadProps) {
+export default function FileUpload({
+  onFileSelect,
+  accept = "image/*",
+  maxSize = 10 * 1024 * 1024,
+  buttonText = "파일 선택",
+  description = "파일을 업로드하세요.",
+}: FileUploadProps) {
   const [isDragOver, setIsDragOver] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -36,8 +44,8 @@ export default function FileUpload({ onFileSelect, accept = "image/*", maxSize =
 
       if (!file) return
 
-      if (!file.type.startsWith("image/")) {
-        setError("Please upload an image file")
+      if (accept && accept !== "*/*" && !file.name.endsWith(accept.replace(".", ""))) {
+        setError(`지원되지 않는 파일 형식입니다 (${accept})`)
         return
       }
 
@@ -81,10 +89,23 @@ export default function FileUpload({ onFileSelect, accept = "image/*", maxSize =
         />
 
         <Upload className="mx-auto h-12 w-12 text-gray-400 mb-4" />
-        <p className="text-lg font-medium text-gray-900 mb-2">Drop your image here, or click to browse</p>
-        <p className="text-sm text-gray-500">Supports PNG, JPG, GIF up to {Math.round(maxSize / (1024 * 1024))}MB</p>
+        <p className="text-lg font-medium text-gray-900 mb-2">{description}</p>
+        <p className="text-sm text-gray-500">
+          {accept === ".pkg"
+            ? ".pkg 파일만 업로드 가능"
+            : `지원되는 형식: ${accept}, 최대 ${Math.round(maxSize / (1024 * 1024))}MB`}
+        </p>
+        <label htmlFor="upload-button">
+          <span
+            className="mt-4 inline-block cursor-pointer bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition"
+            tabIndex={0}
+          >
+            {buttonText}
+          </span>
+        </label>
+        {/* hidden file input (accessibility) */}
+        {/* 실제 input은 이미 위에 있음, label+span은 스타일용 */}
       </div>
-
       {error && (
         <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-md">
           <div className="flex items-center">


### PR DESCRIPTION
# 변경사항

## 로컬 환경에서 연결 작업 완료
로컬 환경에서 연결 작업과 테스트를 완료했습니다. 추후 서버 컴퓨터 세팅이 완료되면 서버를 그쪽으로 이식한 후 연결 부분을 수정해서 완전한 MVP 서비스가 되도록 하겠습니다.

## downscale 페이지

### 다각형 복수 선택
<img width="908" height="750" alt="image" src="https://github.com/user-attachments/assets/d045ae15-ae05-4a85-aa66-e3e70f5bc759" />

서버 API의 구조에 맞게 다각형을 복수 선택할 수 있도록 변경했습니다.

### 다운 스케일 배율 설정
<img width="934" height="265" alt="image" src="https://github.com/user-attachments/assets/3c047e2d-9200-4989-bafe-72b6a01ab92a" />

다운 스케일의 배율을 설정할 수 있도록 변경했습니다.

### 압축완료
<img width="895" height="366" alt="image" src="https://github.com/user-attachments/assets/4114ead8-5e88-43b4-a9ed-4ef0b377bd34" />

압축을 완료하면 결과를 패키지로 받을 수 있도록 구성했습니다.(추후 미리보기 사진 추가 예정)

## restore 페이지

### 파일 업로드
<img width="941" height="411" alt="image" src="https://github.com/user-attachments/assets/f2d22638-a014-4490-9d06-c6e2022fce24" />

패키지 파일만 업로드 할 수 있도록 변경했습니다.

<img width="913" height="288" alt="image" src="https://github.com/user-attachments/assets/df651f8b-52df-4937-844a-c1efe6b482e4" />

패키지를 업로드 하면 압축 모드를 선택할 수 있습니다.

<img width="908" height="663" alt="image" src="https://github.com/user-attachments/assets/c272f8c6-36e3-46a7-997f-96b10bdf86fd" />

압축을 성공적으로 마치면 결과 사진을 보여주고 사용자가 다운 받을 수 있도록 합니다.

