### PR TITLE
feat: 다중 이미지 압축/복원 기능 추가 + 리팩토링

### DIFF
--- a/app/downscale/page.tsx
+++ b/app/downscale/page.tsx
@@ -4,59 +4,42 @@ import { useState, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { ArrowLeft, Download, Loader2 } from "lucide-react"
+import { ArrowLeft, Download, Loader2, PackageOpen, Images } from "lucide-react"
 import FileUpload from "@/components/file-upload"
 import PolygonDrawer from "@/components/polygon-drawer"
+import MultiFileUpload from "@/components/multi-file-upload"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { API_BASE_URL, ENDPOINTS, SCALER_OPTIONS } from "@/lib/constants"
+import { downloadByUrl } from "@/lib/download"
+import type { Point, Polygons } from "@/types/geometry"
 
 /**
- * 점의 좌표를 나타내는 인터페이스
- */
-interface Point {
-  x: number
-  y: number
-}
-
-/**
- * API 호출 시 사용할 상수들
- */
-const API_BASE_URL = "https://5c68fe981b47.ngrok-free.app"
-const COMPRESS_ENDPOINT = "/compress"
-
-/**
- * 다운스케일 배율 옵션
- */
-const SCALER_OPTIONS = [
-  { value: "2", label: "2배" },
-  { value: "3", label: "3배" },
-  { value: "4", label: "4배" }
-]
-
-/**
- * 이미지 압축 페이지 컴포넌트
- * 
- * 기능:
- * - 이미지 파일 업로드
- * - 다각형 영역 선택 (여러 개 가능)
- * - 다운스케일 배율 설정
- * - 백엔드 API 호출로 이미지 압축
- * - .pkg 파일 다운로드
+ * 이미지 압축 페이지 (단일/일괄)
+ * - 단일: 업로드 → 폴리곤 선택 → 배율 선택 → .pkg 반환
+ * - 일괄: 여러 이미지 업로드 → 배율 선택 → pkgs.zip 반환
  */
 export default function DownscalePage() {
   const router = useRouter()
 
-  // 상태 관리
-  const [uploadedFile, setUploadedFile] = useState<File | null>(null) // 업로드된 이미지 파일
-  const [imageUrl, setImageUrl] = useState<string | null>(null) // 이미지 미리보기 URL
-  const [polygons, setPolygons] = useState<Point[][]>([]) // 선택된 다각형들
-  const [scaler, setScaler] = useState<number>(2) // 다운스케일 배율
-  const [isProcessing, setIsProcessing] = useState(false) // 처리 중 상태
-  const [resultUrl, setResultUrl] = useState<string | null>(null) // 결과 파일 URL
-  const [error, setError] = useState<string | null>(null) // 에러 메시지
+  // 공통 상태
+  const [activeTab, setActiveTab] = useState<string>("single")
 
-  /**
-   * 파일 선택 핸들러
-   * 새 파일을 선택하면 이전 상태들을 초기화
-   */
+  // 단일 압축 상태
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null)
+  const [imageUrl, setImageUrl] = useState<string | null>(null)
+  const [polygons, setPolygons] = useState<Polygons>([])
+  const [scaler, setScaler] = useState<number>(2)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [resultUrl, setResultUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // 일괄 압축 상태
+  const [batchFiles, setBatchFiles] = useState<File[]>([])
+  const [isBatchProcessing, setIsBatchProcessing] = useState(false)
+  const [batchResultUrl, setBatchResultUrl] = useState<string | null>(null)
+  const [batchError, setBatchError] = useState<string | null>(null)
+
+  /** 파일 선택(단일) */
   const handleFileSelect = useCallback((file: File) => {
     setUploadedFile(file)
     const url = URL.createObjectURL(file)
@@ -66,25 +49,17 @@ export default function DownscalePage() {
     setError(null)
   }, [])
 
-  /**
-   * 다각형 완성 핸들러
-   * PolygonDrawer에서 다각형이 완성되면 호출됨
-   */
-  const handlePolygonsComplete = useCallback((newPolygons: Point[][]) => {
+  /** 폴리곤 선택 완료(단일) */
+  const handlePolygonsComplete = useCallback((newPolygons: Polygons) => {
     setPolygons(newPolygons)
   }, [])
 
-  /**
-   * 스케일러 변경 핸들러
-   */
+  /** 배율 변경 */
   const handleScalerChange = useCallback((value: string) => {
     setScaler(parseInt(value))
   }, [])
 
-  /**
-   * 이미지 압축 처리 함수
-   * 백엔드 API에 이미지와 다각형 정보를 전송하여 압축 수행
-   */
+  /** 압축 실행(단일) */
   const handleDownscale = useCallback(async () => {
     if (!uploadedFile || polygons.length === 0) return
 
@@ -92,31 +67,24 @@ export default function DownscalePage() {
     setError(null)
 
     try {
-      // FormData 생성
       const formData = new FormData()
       formData.append("image", uploadedFile)
-      
-      // 다각형 좌표를 정수로 반올림하여 JSON 문자열로 변환
       formData.append(
         "polygons",
-        JSON.stringify(
-          polygons.map(poly => poly.map(pt => [Math.round(pt.x), Math.round(pt.y)]))
-        )
+        JSON.stringify(polygons.map(poly => poly.map(pt => [Math.round(pt.x), Math.round(pt.y)])))
       )
       formData.append("scaler", scaler.toString())
 
-      // 백엔드 API 호출
-      const response = await fetch(`${API_BASE_URL}${COMPRESS_ENDPOINT}`, {
+      const response = await fetch(`${API_BASE_URL}${ENDPOINTS.COMPRESS}`, {
         method: "POST",
         body: formData,
       })
 
       if (!response.ok) {
-        const errorData = await response.json()
+        const errorData = await response.json().catch(() => ({}))
         throw new Error(errorData.detail || "압축 처리 중 오류가 발생했습니다.")
       }
 
-      // .pkg 파일을 blob으로 받아서 다운로드 URL 생성
       const blob = await response.blob()
       const url = URL.createObjectURL(blob)
       setResultUrl(url)
@@ -128,101 +96,140 @@ export default function DownscalePage() {
     }
   }, [uploadedFile, polygons, scaler])
 
-  /**
-   * 결과 파일 다운로드 핸들러
-   */
+  /** 결과 .pkg 다운로드 */
   const handleDownload = useCallback(() => {
     if (!resultUrl) return
-
-    const link = document.createElement("a")
-    link.href = resultUrl
-    link.download = "compressed-output.pkg"
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
+    downloadByUrl(resultUrl, "compressed-output.pkg")
   }, [resultUrl])
 
-  /**
-   * 홈으로 돌아가기 핸들러
-   */
+  /** 홈으로 이동 */
   const handleGoHome = useCallback(() => {
     router.push("/")
   }, [router])
 
-  // 압축 버튼 활성화 조건
   const canCompress = uploadedFile && polygons.length > 0 && !isProcessing
+
+  /** 파일 선택(일괄) */
+  const handleBatchFiles = useCallback((files: File[]) => {
+    setBatchFiles(files)
+    setBatchResultUrl(null)
+    setBatchError(null)
+  }, [])
+
+  /** 일괄 압축 실행 */
+  const handleBatchCompress = useCallback(async () => {
+    if (batchFiles.length === 0) return
+
+    setIsBatchProcessing(true)
+    setBatchError(null)
+
+    try {
+      const formData = new FormData()
+      batchFiles.forEach((f) => formData.append("images", f))
+      formData.append("scaler", scaler.toString())
+      formData.append("manual", "false") // 항상 false
+
+      const response = await fetch(`${API_BASE_URL}${ENDPOINTS.AUTO_BATCH_COMPRESS}`, {
+        method: "POST",
+        body: formData,
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(errorData.detail || "일괄 압축 처리 중 오류가 발생했습니다.")
+      }
+
+      const blob = await response.blob()
+      const url = URL.createObjectURL(blob)
+      setBatchResultUrl(url)
+    } catch (error) {
+      console.error("Error batch compress:", error)
+      setBatchError(error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.")
+    } finally {
+      setIsBatchProcessing(false)
+    }
+  }, [batchFiles, scaler])
+
+  /** pkgs.zip 다운로드 */
+  const handleBatchDownload = useCallback(() => {
+    if (!batchResultUrl) return
+    downloadByUrl(batchResultUrl, "pkgs.zip")
+  }, [batchResultUrl])
 
   return (
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="container mx-auto px-4 max-w-4xl">
-        {/* 헤더 */}
-        <div className="flex items-center gap-16 mb-8 mt-16">
-          <Button onClick={handleGoHome} variant="outline" size="sm">
+        {/* 헤더: 타이틀 중앙 정렬, 뒤로가기 버튼 좌측 고정 */}
+        <div className="relative mb-8 mt-16">
+          <Button onClick={handleGoHome} variant="outline" size="sm" className="absolute left-0 top-1/2 -translate-y-1/2">
             <ArrowLeft className="h-4 w-4 mr-2" />
             홈으로 돌아가기
           </Button>
-          <h1 className="text-3xl font-bold text-gray-900">이미지 압축</h1>
+          <h1 className="text-3xl font-bold text-gray-900 text-center">이미지 압축</h1>
         </div>
 
-        {/* 메인 콘텐츠 */}
-        {!imageUrl ? (
-          /* 파일 업로드 영역 */
-          <div className="flex items-center justify-center h-[60vh]">
-          <FileUpload onFileSelect={handleFileSelect} />
-          </div>
-        ) : (
-          <div className="space-y-6">
-            {/* 다각형 선택 영역 */}
-            <div className="bg-white rounded-lg p-6 shadow-sm">
-              <h2 className="text-xl font-semibold mb-4">다각형 영역 선택</h2>
-              <PolygonDrawer imageUrl={imageUrl} onPolygonComplete={handlePolygonsComplete} />
-            </div>
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="single" className="flex items-center gap-2">
+              <PackageOpen className="h-4 w-4" /> 단일 압축
+            </TabsTrigger>
+            <TabsTrigger value="batch" className="flex items-center gap-2">
+              <Images className="h-4 w-4" /> 일괄 압축
+            </TabsTrigger>
+          </TabsList>
 
-            {/* 압축 설정 영역 */}
-            {polygons.length > 0 && (
+          {/* 단일 압축 탭 */}
+          <TabsContent value="single" className="mt-6 space-y-6">
+            {/* 업로드/그리기 영역 */}
+            {!imageUrl ? (
+              <div className="flex items-center justify-center h-[60vh]">
+                <FileUpload onFileSelect={handleFileSelect} />
+              </div>
+            ) : (
               <div className="bg-white rounded-lg p-6 shadow-sm">
-                <h2 className="text-xl font-semibold mb-4">압축 설정</h2>
-                <div className="space-y-4">
-                  {/* 다운스케일 배율 선택 */}
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      다운스케일 배율
-                    </label>
-                    <Select value={scaler.toString()} onValueChange={handleScalerChange}>
-                      <SelectTrigger className="w-48">
-                        <SelectValue placeholder="배율 선택" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {SCALER_OPTIONS.map(option => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  
-                  {/* 압축 실행 버튼 */}
-                  <div className="flex justify-center">
-                    <Button 
-                      onClick={handleDownscale} 
-                      disabled={!canCompress} 
-                      size="lg" 
-                      className="px-8"
-                    >
-                      {isProcessing ? (
-                        <>
-                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                          압축 중...
-                        </>
-                      ) : (
-                        "이미지 압축"
-                      )}
-                    </Button>
-                  </div>
-                </div>
+                <h2 className="text-xl font-semibold mb-4">다각형 영역 선택</h2>
+                <PolygonDrawer imageUrl={imageUrl} onPolygonComplete={handlePolygonsComplete} />
               </div>
             )}
+
+            {/* 설정 영역: 업로드 전에도 항상 노출 */}
+            <div className="bg-white rounded-lg p-6 shadow-sm">
+              <h2 className="text-xl font-semibold mb-4">압축 설정</h2>
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">다운스케일 배율</label>
+                  <Select value={scaler.toString()} onValueChange={handleScalerChange}>
+                    <SelectTrigger className="w-48">
+                      <SelectValue placeholder="배율 선택" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SCALER_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="flex justify-center">
+                  <Button onClick={handleDownscale} disabled={!canCompress} size="lg" className="px-8">
+                    {isProcessing ? (
+                      <>
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        압축 중...
+                      </>
+                    ) : (
+                      "이미지 압축"
+                    )}
+                  </Button>
+                </div>
+
+                {!uploadedFile && (
+                  <p className="text-xs text-gray-500 text-center">이미지를 업로드하고 영역을 선택해야 압축을 시작할 수 있습니다.</p>
+                )}
+              </div>
+            </div>
 
             {/* 에러 메시지 */}
             {error && (
@@ -236,31 +243,16 @@ export default function DownscalePage() {
               <div className="bg-white rounded-lg p-6 shadow-sm">
                 <h2 className="text-xl font-semibold mb-4">압축 결과</h2>
                 <div className="space-y-4">
-                  {/* 성공 메시지 */}
                   <div className="text-center p-8 border-2 border-dashed border-gray-300 rounded-lg">
                     <div className="text-gray-600 mb-4">
-                      <svg 
-                        className="mx-auto h-12 w-12 text-gray-400" 
-                        stroke="currentColor" 
-                        fill="none" 
-                        viewBox="0 0 48 48"
-                        aria-hidden="true"
-                      >
-                        <path 
-                          d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" 
-                          strokeWidth={2} 
-                          strokeLinecap="round" 
-                          strokeLinejoin="round" 
-                        />
+                      <svg className="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
+                        <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
                       </svg>
                     </div>
                     <p className="text-lg font-medium text-gray-900">압축 완료!</p>
-                    <p className="text-sm text-gray-500">
-                      사진이 성공적으로 {scaler}배 다운스케일로 압축되었습니다!(다각형 개수: {polygons.length})
-                    </p>
+                    <p className="text-sm text-gray-500">사진이 성공적으로 {scaler}배 다운스케일로 압축되었습니다!(다각형 개수: {polygons.length})</p>
                   </div>
-                  
-                  {/* 다운로드 버튼 */}
+
                   <div className="flex justify-center">
                     <Button onClick={handleDownload}>
                       <Download className="h-4 w-4 mr-2" />
@@ -270,8 +262,82 @@ export default function DownscalePage() {
                 </div>
               </div>
             )}
-          </div>
-        )}
+          </TabsContent>
+
+          {/* 일괄 압축 탭 */}
+          <TabsContent value="batch" className="mt-6">
+            <div className="space-y-6">
+              <div className="bg-white rounded-lg p-6 shadow-sm">
+                <h2 className="text-xl font-semibold mb-4">이미지 다중 업로드</h2>
+                <MultiFileUpload onFilesSelect={handleBatchFiles} accept="image/*" />
+              </div>
+
+              <div className="bg-white rounded-lg p-6 shadow-sm">
+                <h2 className="text-xl font-semibold mb-4">압축 설정</h2>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">다운스케일 배율</label>
+                    <Select value={scaler.toString()} onValueChange={handleScalerChange}>
+                      <SelectTrigger className="w-48">
+                        <SelectValue placeholder="배율 선택" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SCALER_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="flex justify-center">
+                    <Button onClick={handleBatchCompress} disabled={isBatchProcessing || batchFiles.length === 0} size="lg" className="px-8">
+                      {isBatchProcessing ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          일괄 압축 중...
+                        </>
+                      ) : (
+                        "일괄 압축"
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+
+              {batchError && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                  <p className="text-red-700 text-sm">{batchError}</p>
+                </div>
+              )}
+
+              {batchResultUrl && (
+                <div className="bg-white rounded-lg p-6 shadow-sm">
+                  <h2 className="text-xl font-semibold mb-4">일괄 압축 결과</h2>
+                  <div className="space-y-4">
+                    <div className="text-center p-8 border-2 border-dashed border-gray-300 rounded-lg">
+                      <div className="text-gray-600 mb-4">
+                        <svg className="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
+                          <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      </div>
+                      <p className="text-lg font-medium text-gray-900">일괄 압축 완료!</p>
+                      <p className="text-sm text-gray-500">선택한 이미지들이 {scaler}배 다운스케일로 압축되어 pkgs.zip으로 생성되었습니다.</p>
+                    </div>
+
+                    <div className="flex justify-center">
+                      <Button onClick={handleBatchDownload}>
+                        <Download className="h-4 w-4 mr-2" />
+                        pkgs.zip 다운로드
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   )

--- a/app/restore/page.tsx
+++ b/app/restore/page.tsx
@@ -4,46 +4,37 @@ import { useState, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { ArrowLeft, Download, Loader2, Upload } from "lucide-react"
+import { ArrowLeft, Download, Loader2, PackageOpen, Images } from "lucide-react"
 import FileUpload from "@/components/file-upload"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { API_BASE_URL, ENDPOINTS, MRS3_MODE_OPTIONS } from "@/lib/constants"
+import { downloadByUrl } from "@/lib/download"
 
 /**
- * API 호출 시 사용할 상수들
- */
-const API_BASE_URL = "https://5c68fe981b47.ngrok-free.app"
-const RESTORE_ENDPOINT = "/restore"
-
-/**
- * 업스케일 방식 옵션들
- */
-const MRS3_MODE_OPTIONS = [
-  { value: "-1", label: "EDSR (고품질 AI 업스케일)", description: "AI 기반 고품질 업스케일링" },
-  { value: "0", label: "OpenCV", description: "빠른 처리 속도" }
-]
-
-/**
- * 이미지 복원 페이지 컴포넌트
- * 
- * 기능:
- * - .pkg 파일 업로드
- * - 업스케일 방식 선택 (EDSR 또는 OpenCV)
- * - 백엔드 API 호출로 이미지 복원
- * - 복원된 이미지 다운로드
+ * 이미지 복원 페이지 (단일/일괄)
+ * - 단일: .pkg 업로드 → 복원방식 선택 → 복원 이미지 반환
+ * - 일괄: pkgs.zip 업로드 → 복원 zip 반환
  */
 export default function RestorePage() {
   const router = useRouter()
 
-  // 상태 관리
-  const [uploadedFile, setUploadedFile] = useState<File | null>(null) // 업로드된 .pkg 파일
-  const [mrs3Mode, setMrs3Mode] = useState<number>(-1) // 업스케일 방식
-  const [isProcessing, setIsProcessing] = useState(false) // 처리 중 상태
-  const [resultUrl, setResultUrl] = useState<string | null>(null) // 결과 이미지 URL
-  const [error, setError] = useState<string | null>(null) // 에러 메시지
+  // 공통 상태
+  const [activeTab, setActiveTab] = useState<string>("single")
 
-  /**
-   * 파일 선택 핸들러
-   * .pkg 파일인지 확인하고 상태 업데이트
-   */
+  // 단일 복원 상태
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null)
+  const [mrs3Mode, setMrs3Mode] = useState<number>(-1)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [resultUrl, setResultUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // 일괄 복원 상태
+  const [zipFile, setZipFile] = useState<File | null>(null)
+  const [isBatchProcessing, setIsBatchProcessing] = useState(false)
+  const [batchResultUrl, setBatchResultUrl] = useState<string | null>(null)
+  const [batchError, setBatchError] = useState<string | null>(null)
+
+  /** 파일 선택(.pkg) */
   const handleFileSelect = useCallback((file: File) => {
     if (file && file.name.endsWith('.pkg')) {
       setUploadedFile(file)
@@ -54,17 +45,12 @@ export default function RestorePage() {
     }
   }, [])
 
-  /**
-   * 업스케일 방식 변경 핸들러
-   */
+  /** 복원 방식 변경 */
   const handleMrs3ModeChange = useCallback((value: string) => {
     setMrs3Mode(parseInt(value))
   }, [])
 
-  /**
-   * 이미지 복원 처리 함수
-   * 백엔드 API에 .pkg 파일과 복원 방식을 전송하여 복원 수행
-   */
+  /** 복원 실행(단일) */
   const handleRestore = useCallback(async () => {
     if (!uploadedFile) return
 
@@ -72,23 +58,20 @@ export default function RestorePage() {
     setError(null)
 
     try {
-      // FormData 생성
       const formData = new FormData()
       formData.append("pkg", uploadedFile)
       formData.append("mrs3_mode", mrs3Mode.toString())
 
-      // 백엔드 API 호출
-      const response = await fetch(`${API_BASE_URL}${RESTORE_ENDPOINT}`, {
+      const response = await fetch(`${API_BASE_URL}${ENDPOINTS.RESTORE}`, {
         method: "POST",
         body: formData,
       })
 
       if (!response.ok) {
-        const errorData = await response.json()
+        const errorData = await response.json().catch(() => ({}))
         throw new Error(errorData.detail || "복원 처리 중 오류가 발생했습니다.")
       }
 
-      // 복원된 이미지를 blob으로 받아서 미리보기 URL 생성
       const blob = await response.blob()
       const url = URL.createObjectURL(blob)
       setResultUrl(url)
@@ -100,115 +83,137 @@ export default function RestorePage() {
     }
   }, [uploadedFile, mrs3Mode])
 
-  /**
-   * 결과 이미지 다운로드 핸들러
-   */
+  /** 복원 이미지 다운로드 */
   const handleDownload = useCallback(() => {
     if (!resultUrl) return
-
-    const link = document.createElement("a")
-    link.href = resultUrl
-    link.download = "restored-image.png"
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
+    downloadByUrl(resultUrl, "restored-image.png")
   }, [resultUrl])
 
-  /**
-   * 홈으로 돌아가기 핸들러
-   */
+  /** 홈으로 이동 */
   const handleGoHome = useCallback(() => {
     router.push("/")
   }, [router])
 
-  // 복원 버튼 활성화 조건
+  // 일괄 복원 핸들러들
+  const handleZipSelect = useCallback((file: File) => {
+    if (file && file.name.toLowerCase().endsWith('.zip')) {
+      setZipFile(file)
+      setBatchResultUrl(null)
+      setBatchError(null)
+    } else {
+      setBatchError('zip 파일만 업로드 가능합니다.')
+    }
+  }, [])
+
+  const handleBatchRestore = useCallback(async () => {
+    if (!zipFile) return
+
+    setIsBatchProcessing(true)
+    setBatchError(null)
+
+    try {
+      const formData = new FormData()
+      formData.append("pkgs_zip", zipFile)
+      formData.append("mrs3_mode", mrs3Mode.toString())
+
+      const response = await fetch(`${API_BASE_URL}${ENDPOINTS.BATCH_RESTORE}`, {
+        method: "POST",
+        body: formData,
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(errorData.detail || "일괄 복원 처리 중 오류가 발생했습니다.")
+      }
+
+      const blob = await response.blob()
+      const url = URL.createObjectURL(blob)
+      setBatchResultUrl(url)
+    } catch (error) {
+      console.error("Error batch restore:", error)
+      setBatchError(error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.")
+    } finally {
+      setIsBatchProcessing(false)
+    }
+  }, [zipFile, mrs3Mode])
+
+  const handleBatchDownload = useCallback(() => {
+    if (!batchResultUrl) return
+    downloadByUrl(batchResultUrl, "restored_imgs.zip")
+  }, [batchResultUrl])
+
   const canRestore = uploadedFile && !isProcessing
 
-  // 선택된 복원 방식에 대한 설명 텍스트
   const selectedModeDescription = MRS3_MODE_OPTIONS.find(
-    option => parseInt(option.value) === mrs3Mode
+    (option) => parseInt(option.value) === mrs3Mode,
   )?.description || ""
 
   return (
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="container mx-auto px-4 max-w-4xl">
-        {/* 헤더 */}
-        <div className="flex items-center gap-16 mb-8 mt-16 ">
-          <Button onClick={handleGoHome} variant="outline" size="sm">
+        {/* 헤더: 타이틀 중앙 정렬, 뒤로가기 버튼 좌측 고정 */}
+        <div className="relative mb-8 mt-16 ">
+          <Button onClick={handleGoHome} variant="outline" size="sm" className="absolute left-0 top-1/2 -translate-y-1/2">
             <ArrowLeft className="h-4 w-4 mr-2" />
             홈으로 돌아가기
           </Button>
-          <h1 className="text-3xl font-bold text-gray-900">이미지 복원</h1>
+        <h1 className="text-3xl font-bold text-gray-900 text-center">이미지 복원</h1>
         </div>
 
-        <div className="space-y-6">
-          {/* PKG 파일 업로드 섹션 */}
-          
-        <div className="flex items-center justify-center h-[60vh]">
-          <div className="w-full max-w-2xl px-4">
-            <FileUpload
-              onFileSelect={handleFileSelect}
-              accept=".pkg"
-              maxSize={10 * 1024 * 1024}
-            />
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="single" className="flex items-center gap-2">
+              <PackageOpen className="h-4 w-4" /> 단일 복원
+            </TabsTrigger>
+            <TabsTrigger value="batch" className="flex items-center gap-2">
+              <Images className="h-4 w-4" /> 일괄 복원
+            </TabsTrigger>
+          </TabsList>
 
-            {/* 업로드된 파일 정보 표시 */}
-            {uploadedFile && (
-              <div className="mt-4 p-3 bg-green-50 border border-green-200 rounded-md">
-                <p className="text-sm text-green-700">
-                  선택된 파일: {uploadedFile.name}
-                </p>
+          {/* 단일 복원 탭 */}
+          <TabsContent value="single" className="mt-6 space-y-6">
+            {/* 업로드 영역 */}
+            <div className="flex items-center justify-center h-[40vh]">
+              <div className="w-full max-w-2xl px-4">
+                <FileUpload onFileSelect={handleFileSelect} accept=".pkg" maxSize={10 * 1024 * 1024} />
+
+                {uploadedFile && (
+                  <div className="mt-4 p-3 bg-green-50 border border-green-200 rounded-md">
+                    <p className="text-sm text-green-700">선택된 파일: {uploadedFile.name}</p>
+                  </div>
+                )}
+
+                {error && (
+                  <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-md">
+                    <p className="text-sm text-red-700">{error}</p>
+                  </div>
+                )}
               </div>
-            )}
+            </div>
 
-            {/* 에러 메시지 표시 */}
-            {error && (
-              <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-md">
-                <p className="text-sm text-red-700">{error}</p>
-              </div>
-            )}
-          </div>
-        </div>
-
-
-          {/* 복원 설정 섹션 */}
-          {uploadedFile && (
+            {/* 설정 영역: 업로드 전에도 항상 노출 */}
             <div className="bg-white rounded-lg p-6 shadow-sm">
               <h2 className="text-xl font-semibold mb-4">복원 설정</h2>
               <div className="space-y-4">
-                {/* 업스케일 방식 선택 */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    업스케일 방식
-                  </label>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">업스케일 방식</label>
                   <Select value={mrs3Mode.toString()} onValueChange={handleMrs3ModeChange}>
                     <SelectTrigger className="w-64">
                       <SelectValue placeholder="업스케일 방식 선택" />
                     </SelectTrigger>
                     <SelectContent>
-                      {MRS3_MODE_OPTIONS.map(option => (
+                      {MRS3_MODE_OPTIONS.map((option) => (
                         <SelectItem key={option.value} value={option.value}>
                           {option.label}
                         </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
-                  
-                  {/* 선택된 방식에 대한 설명 */}
-                  <p className="text-xs text-gray-500 mt-1">
-                    {selectedModeDescription}
-                    {mrs3Mode === -1 && " - 처리 시간이 오래 걸릴 수 있습니다."}
-                  </p>
+                  <p className="text-xs text-gray-500 mt-1">{selectedModeDescription}{mrs3Mode === -1 && " - 처리 시간이 오래 걸릴 수 있습니다."}</p>
                 </div>
-                
-                {/* 복원 실행 버튼 */}
+
                 <div className="flex justify-center">
-                  <Button 
-                    onClick={handleRestore} 
-                    disabled={!canRestore} 
-                    size="lg" 
-                    className="px-8"
-                  >
+                  <Button onClick={handleRestore} disabled={!canRestore} size="lg" className="px-8">
                     {isProcessing ? (
                       <>
                         <Loader2 className="h-4 w-4 mr-2 animate-spin" />
@@ -219,39 +224,109 @@ export default function RestorePage() {
                     )}
                   </Button>
                 </div>
-              </div>
-            </div>
-          )}
 
-          {/* 복원 결과 섹션 */}
-          {resultUrl && (
-            <div className="bg-white rounded-lg p-6 shadow-sm">
-              <h2 className="text-xl font-semibold mb-4">복원 결과</h2>
-              <div className="space-y-4">
-                {/* 복원된 이미지 표시 */}
-                <div className="flex justify-center">
-                  <img
-                    src={resultUrl}
-                    alt="복원된 이미지"
-                    className="max-w-full h-auto rounded border shadow-sm"
-                    style={{ maxHeight: "600px" }}
-                  />
-                </div>
-                
-                {/* 복원 정보 및 다운로드 버튼 */}
-                <div className="text-center">
-                  <p className="text-sm text-gray-600 mb-4">
-                    {mrs3Mode === -1 ? 'EDSR AI 업스케일링' : `OpenCV 방식 (모드 ${mrs3Mode})`}으로 복원된 이미지입니다.
-                  </p>
-                  <Button onClick={handleDownload}>
-                    <Download className="h-4 w-4 mr-2" />
-                    복원 이미지 다운로드
-                  </Button>
-                </div>
+                {!uploadedFile && (
+                  <p className="text-xs text-gray-500 text-center">.pkg 파일을 업로드해야 복원을 시작할 수 있습니다.</p>
+                )}
               </div>
             </div>
-          )}
-        </div>
+
+            {/* 복원 결과 */}
+            {resultUrl && (
+              <div className="bg-white rounded-lg p-6 shadow-sm">
+                <h2 className="text-xl font-semibold mb-4">복원 결과</h2>
+                <div className="space-y-4">
+                  <div className="flex justify-center">
+                    <img src={resultUrl} alt="복원된 이미지" className="max-w-full h-auto rounded border shadow-sm" style={{ maxHeight: "600px" }} />
+                  </div>
+                  <div className="text-center">
+                    <p className="text-sm text-gray-600 mb-4">{mrs3Mode === -1 ? 'EDSR AI 업스케일링' : `OpenCV 방식 (모드 ${mrs3Mode})`}으로 복원된 이미지입니다.</p>
+                    <Button onClick={handleDownload}>
+                      <Download className="h-4 w-4 mr-2" /> 복원 이미지 다운로드
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </TabsContent>
+
+          {/* 일괄 복원 탭 */}
+          <TabsContent value="batch" className="mt-6">
+            <div className="space-y-6">
+              <div className="bg-white rounded-lg p-6 shadow-sm">
+                <h2 className="text-xl font-semibold mb-4">pkgs.zip 업로드</h2>
+                <FileUpload onFileSelect={handleZipSelect} accept=".zip" maxSize={100 * 1024 * 1024} />
+                {zipFile && (
+                  <div className="mt-4 p-3 bg-green-50 border border-green-200 rounded-md">
+                    <p className="text-sm text-green-700">선택된 파일: {zipFile.name}</p>
+                  </div>
+                )}
+                {batchError && (
+                  <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-md">
+                    <p className="text-sm text-red-700">{batchError}</p>
+                  </div>
+                )}
+              </div>
+
+              <div className="bg-white rounded-lg p-6 shadow-sm">
+                <h2 className="text-xl font-semibold mb-4">복원 설정</h2>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">업스케일 방식</label>
+                    <Select value={mrs3Mode.toString()} onValueChange={handleMrs3ModeChange}>
+                      <SelectTrigger className="w-64">
+                        <SelectValue placeholder="업스케일 방식 선택" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {MRS3_MODE_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="flex justify-center">
+                    <Button onClick={handleBatchRestore} disabled={isBatchProcessing || !zipFile} size="lg" className="px-8">
+                      {isBatchProcessing ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          일괄 복원 중...
+                        </>
+                      ) : (
+                        "일괄 복원"
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+
+              {batchResultUrl && (
+                <div className="bg-white rounded-lg p-6 shadow-sm">
+                  <h2 className="text-xl font-semibold mb-4">일괄 복원 결과</h2>
+                  <div className="space-y-4">
+                    <div className="text-center p-8 border-2 border-dashed border-gray-300 rounded-lg">
+                      <div className="text-gray-600 mb-4">
+                        <svg className="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
+                          <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      </div>
+                      <p className="text-lg font-medium text-gray-900">일괄 복원 완료!</p>
+                      <p className="text-sm text-gray-500">업로드한 pkgs.zip이 복원되어 restored_imgs.zip으로 제공됩니다.</p>
+                    </div>
+                    <div className="flex justify-center">
+                      <Button onClick={handleBatchDownload}>
+                        <Download className="h-4 w-4 mr-2" />
+                        restored_imgs.zip 다운로드
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   )

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -68,8 +68,13 @@ export default function FileUpload({
     }
 
     // .pkg 파일 확장자 검사 (accept가 ".pkg"인 경우)
-    if (accept === ".pkg" && !file.name.endsWith(".pkg")) {
+    if (accept === ".pkg" && !file.name.toLowerCase().endsWith(".pkg")) {
       return ".pkg 파일만 업로드할 수 있습니다."
+    }
+
+    // .zip 파일 확장자 검사 (accept가 ".zip"인 경우)
+    if (accept === ".zip" && !file.name.toLowerCase().endsWith(".zip")) {
+      return "pkgs.zip 파일만 업로드할 수 있습니다."
     }
 
     // 파일 크기 검사
@@ -134,17 +139,24 @@ export default function FileUpload({
   // 파일 타입에 따른 UI 텍스트 설정
   const isImageUpload = accept === "image/*"
   const isPkgUpload = accept === ".pkg"
+  const isZipUpload = accept === ".zip"
   
   const getUploadText = () => {
     if (isPkgUpload) {
       return {
         title: "PKG 파일을 여기에 드롭하거나 클릭하여 선택하세요",
-        subtitle: `압축된 .pkg 파일만 지원 (최대 ${Math.round(maxSize / (1024 * 1024))}MB)`
+        subtitle: `압축된 .pkg 파일만 지원 (최대 ${Math.round(maxSize / (1024 * 1024))}MB)`,
+      }
+    }
+    if (isZipUpload) {
+      return {
+        title: "pkgs.zip 파일을 여기에 드롭하거나 클릭하여 선택하세요",
+        subtitle: `복원용 pkgs.zip 파일만 지원 (최대 ${Math.round(maxSize / (1024 * 1024))}MB)`,
       }
     }
     return {
       title: "이미지를 여기에 드롭하거나 클릭하여 선택하세요",
-      subtitle: `PNG, JPG, GIF 형식 지원 (최대 ${Math.round(maxSize / (1024 * 1024))}MB)`
+      subtitle: `PNG, JPG, GIF 형식 지원 (최대 ${Math.round(maxSize / (1024 * 1024))}MB)`,
     }
   }
 

--- a/components/multi-file-upload.tsx
+++ b/components/multi-file-upload.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import type React from "react"
+import { useCallback, useMemo, useState } from "react"
+import { Upload, X, Images } from "lucide-react"
+
+interface MultiFileUploadProps {
+  onFilesSelect: (files: File[]) => void
+  accept?: string
+  maxSize?: number // bytes
+  maxFiles?: number
+}
+
+const DEFAULT_ACCEPT = "image/*"
+const DEFAULT_MAX_SIZE = 10 * 1024 * 1024 // 10MB
+const DEFAULT_MAX_FILES = 50
+
+export default function MultiFileUpload({
+  onFilesSelect,
+  accept = DEFAULT_ACCEPT,
+  maxSize = DEFAULT_MAX_SIZE,
+  maxFiles = DEFAULT_MAX_FILES,
+}: MultiFileUploadProps) {
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([])
+
+  const validateFiles = useCallback(
+    (files: File[]): string | null => {
+      if (!files.length) return "파일이 선택되지 않았습니다."
+      if (files.length > maxFiles) return `최대 ${maxFiles}개까지 업로드할 수 있습니다.`
+      for (const file of files) {
+        if (accept === "image/*" && !file.type.startsWith("image/")) {
+          return "이미지 파일만 업로드할 수 있습니다."
+        }
+        if (file.size > maxSize) {
+          const mb = Math.round(maxSize / (1024 * 1024))
+          return `파일 크기가 너무 큽니다. ${mb}MB 이하 파일만 가능합니다.`
+        }
+      }
+      return null
+    },
+    [accept, maxFiles, maxSize],
+  )
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      setIsDragOver(false)
+      setError(null)
+      const files = Array.from(e.dataTransfer.files)
+      const err = validateFiles(files)
+      if (err) {
+        setError(err)
+        return
+      }
+      setSelectedFiles(files)
+      onFilesSelect(files)
+    },
+    [onFilesSelect, validateFiles],
+  )
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+  }, [])
+
+  const handleFileInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files || [])
+      setError(null)
+      const err = validateFiles(files)
+      if (err) {
+        setError(err)
+        return
+      }
+      setSelectedFiles(files)
+      onFilesSelect(files)
+    },
+    [onFilesSelect, validateFiles],
+  )
+
+  const summaryText = useMemo(() => {
+    if (!selectedFiles.length) return null
+    const totalSize = selectedFiles.reduce((sum, f) => sum + f.size, 0)
+    const mb = (totalSize / (1024 * 1024)).toFixed(1)
+    return `${selectedFiles.length}개 선택됨 • 총 ${mb}MB`
+  }, [selectedFiles])
+
+  return (
+    <div className="w-full max-w-2xl mx-auto">
+      <div
+        className={`relative border-2 border-dashed rounded-lg p-12 text-center transition-colors min-h-[20rem] flex flex-col items-center justify-center ${
+          isDragOver ? "border-blue-500 bg-blue-50" : "border-gray-300 hover:border-gray-400"
+        }`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <input
+          type="file"
+          accept={accept}
+          multiple
+          onChange={handleFileInput}
+          className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+        />
+
+        <Images className="mx-auto h-12 w-12 text-gray-400 mb-4" />
+        <p className="text-lg font-medium text-gray-900 mb-2">
+          여러 이미지를 여기에 드롭하거나 클릭하여 선택하세요
+        </p>
+        <p className="text-sm text-gray-500">
+          PNG, JPG 등 이미지 최대 {Math.round(maxSize / (1024 * 1024))}MB • 최대 {maxFiles}개
+        </p>
+
+        {summaryText && (
+          <div className="mt-4 text-sm text-gray-600">{summaryText}</div>
+        )}
+      </div>
+
+      {selectedFiles.length > 0 && (
+        <ul className="mt-4 space-y-1 text-sm text-gray-700 max-h-40 overflow-auto">
+          {selectedFiles.map((f) => (
+            <li key={f.name} className="truncate">• {f.name}</li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-md">
+          <div className="flex items-center">
+            <X className="h-4 w-4 text-red-500 mr-2" />
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * 공통 상수 모음
+ * - 프론트 전역에서 재사용되는 API URL, 엔드포인트, 선택 옵션 등을 제공합니다.
+ * - 환경 변수: NEXT_PUBLIC_API_BASE_URL (예: http://localhost:8000)
+ */
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000"
+
+// 백엔드 엔드포인트
+export const ENDPOINTS = {
+  COMPRESS: "/compress",
+  AUTO_BATCH_COMPRESS: "/auto-batch-compress",
+  RESTORE: "/restore",
+  BATCH_RESTORE: "/batch-restore",
+} as const
+
+// 다운스케일 배율 옵션
+export const SCALER_OPTIONS = [
+  { value: "2", label: "2배" },
+  { value: "3", label: "3배" },
+  { value: "4", label: "4배" },
+] as const
+
+// 복원(업스케일) 방식 옵션
+export const MRS3_MODE_OPTIONS = [
+  { value: "-1", label: "EDSR (고품질 AI 업스케일)", description: "AI 기반 고품질 업스케일링" },
+  { value: "0", label: "OpenCV", description: "빠른 처리 속도" },
+] as const

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -1,0 +1,26 @@
+/**
+ * 브라우저에서 Blob/URL을 다운로드 링크로 저장하는 유틸리티
+ */
+export function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  try {
+    const link = document.createElement("a")
+    link.href = url
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  } finally {
+    // 메모리 누수 방지
+    setTimeout(() => URL.revokeObjectURL(url), 0)
+  }
+}
+
+export function downloadByUrl(url: string, filename: string) {
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}

--- a/types/geometry.ts
+++ b/types/geometry.ts
@@ -1,0 +1,10 @@
+/**
+ * 기하 타입 모음 (프론트 전역 공유)
+ */
+export interface Point {
+  x: number
+  y: number
+}
+
+export type Polygon = Point[]
+export type Polygons = Polygon[]


### PR DESCRIPTION
## 다중 이미지 압축

### 이미지 압축 화면
<img width="901" height="752" alt="image" src="https://github.com/user-attachments/assets/d9a5a21f-b4bd-42ed-8b4f-c2f78ade6876" />

### 파일 업로드 시
<img width="885" height="739" alt="image" src="https://github.com/user-attachments/assets/51f7931c-023f-4678-9939-c10d5ba5fc7e" />

### 압축 성공
<img width="972" height="624" alt="image" src="https://github.com/user-attachments/assets/7aadbb4d-b40f-479a-9c9b-df20f343d76d" />
(압축 성공 메시지는 다른 디자인으로 표현되는 것이 좋아보입니다. 이건 나중에 수정하도록 하겠습니다)

## 다중 이미지 복원

### 이미지 복원 화면
<img width="909" height="758" alt="image" src="https://github.com/user-attachments/assets/5ef1e7b7-0e9d-4016-9c4a-c1c3b27ccc0a" />

### 파일 업로드 시
<img width="970" height="755" alt="image" src="https://github.com/user-attachments/assets/bfd1e521-4f42-4755-8b19-dd57d38696f5" />

### 복원 성공
<img width="906" height="592" alt="image" src="https://github.com/user-attachments/assets/caa150cb-ceca-4c90-af90-5e34cf8b2dde" />
(이것도 역시 성공 메시지 표현하는 디자인은 수정해야 할 것 같습니다.)

### 리팩토링
GPT 5와 커서의 힘을 빌려서(...) 프론트 구조를 전체적으로 리팩토링 했습니다!

### 테스트 방법

먼저 아래의 방법대로 백엔드를 실행합니다.

1. **서버 레포지토리를 clone/pull 합니다.**
2. **poetry 가상환경을 활성화합니다.**
(예: `poetry shell` 또는 `poetry env info --path` → `source .../bin/activate`)
3. **루트 폴더에서 다음 명령어로 서버를 실행합니다.**
    
    `uvicorn main:app --reload`
    
4. **웹브라우저에서 http://127.0.0.1:8000/docs 에 접속합니다.**
5. **Swagger UI의 Try it out을 눌러 API 요청을 실제로 보낼 수 있습니다**

이후 프론트 레포지토리를 clone하고, npm run dev를 터미널에 입력하면 localhost:3000에서 자유롭게 테스트하실 수 있습니다!