### PR TITLE
feat(app): 글로벌 네비 오버레이 + 로딩 UX 추가, 스크롤/깜빡임 수정

### DIFF
--- a/app/downscale/page.tsx
+++ b/app/downscale/page.tsx
@@ -14,6 +14,8 @@ import { downloadByUrl } from "@/lib/download"
 import type { Polygons } from "@/types/geometry"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
+import { useRouteOverlay } from "../providers/route-overlay";
+
 
 /**
  * 이미지 압축 페이지 (단일/일괄)
@@ -101,9 +103,13 @@ export default function DownscalePage() {
     downloadByUrl(resultUrl, "compressed-output.pkg")
   }, [resultUrl])
 
-  const handleGoHome = useCallback(() => {
-    router.push("/")
-  }, [router])
+  const { setIsNavigating } = useRouteOverlay();
+
+const handleGoHome = useCallback(() => {
+  setIsNavigating(true);   // 오버레이 켜기
+  router.push("/");        // 이동 시작
+}, [router, setIsNavigating]);
+
 
   const canCompress = uploadedFile && polygons.length > 0 && !isProcessing
 
@@ -153,7 +159,7 @@ export default function DownscalePage() {
   }, [batchResultUrl])
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="h-screen bg-gray-50 py-8 overflow-y-auto no-scrollbar">
       <div className="container mx-auto px-4 max-w-4xl">
         {/* 헤더: 타이틀 중앙 정렬, 뒤로가기 버튼 좌측 고정 */}
         <div className="relative mb-8 mt-16">
@@ -175,17 +181,21 @@ export default function DownscalePage() {
           </TabsList>
 
           {/* 단일 압축 탭 */}
-          <TabsContent value="single" className="mt-6 space-y-6">
+          <TabsContent value="single" className="mt-6">
+            <div className="space-y-6">
+            <div className="bg-white rounded-lg p-6 shadow-sm">
+              <h2 className="text-xl font-semibold mb-4">이미지 업로드</h2>
             {!imageUrl ? (
-              <div className="flex items-center justify-center h-[60vh]">
+              
                 <FileUpload onFileSelect={handleFileSelect} />
-              </div>
+              
             ) : (
               <div className="bg-white rounded-lg p-6 shadow-sm">
                 <h2 className="text-xl font-semibold mb-4">다각형 영역 선택</h2>
                 <PolygonDrawer imageUrl={imageUrl} onPolygonComplete={handlePolygonsComplete} />
               </div>
             )}
+            </div>
 
             <div className="bg-white rounded-lg p-6 shadow-sm">
               <h2 className="text-xl font-semibold mb-4">압축 설정</h2>
@@ -226,7 +236,7 @@ export default function DownscalePage() {
                   </Button>
                 </div>
 
-                {!uploadedFile && (
+                {(!uploadedFile || polygons.length === 0)&& (
                   <p className="text-xs text-gray-500 text-center">이미지를 업로드하고 영역을 선택해야 압축을 시작할 수 있습니다.</p>
                 )}
               </div>
@@ -261,6 +271,7 @@ export default function DownscalePage() {
                 </div>
               </div>
             )}
+            </div>
           </TabsContent>
 
           {/* 일괄 압축 탭 */}
@@ -302,6 +313,9 @@ export default function DownscalePage() {
                       )}
                     </Button>
                   </div>
+                  {batchFiles.length === 0 && (
+                  <p className="text-xs text-gray-500 text-center">이미지를 업로드해야 압축을 시작할 수 있습니다.</p>
+                )}
                 </div>
               </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,14 @@ body {
   .text-balance {
     text-wrap: balance;
   }
+    /* 스크롤은 되지만, 스크롤바 UI만 숨김 */
+  .no-scrollbar {
+    -ms-overflow-style: none;  /* IE, Edge */
+    scrollbar-width: none;     /* Firefox */
+  }
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;             /* Chrome, Safari, Opera */
+  }
 }
 
 @layer base {
@@ -85,10 +93,14 @@ body {
 }
 
 @layer base {
+  /* ➊ 바디 스크롤 끄기 위해 높이 확정 */
+  html, body { height: 100%; }
   * {
     @apply border-border;
   }
+  /* ➋ body 스크롤 비활성화 + 기존 apply 유지 */
   body {
     @apply bg-background text-foreground;
+    overflow: hidden;   /* ★ 스크롤바/스크롤 자체 OFF */
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,9 +3,8 @@ import "./globals.css";
 import { RouteOverlayProvider } from "./providers/route-overlay";
 
 export const metadata: Metadata = {
-  title: "v0 App",
-  description: "Created with v0",
-  generator: "v0.dev",
+  title: "mrs3_frontend",
+  description: "mrs3_frontend",
 };
 
 export default function RootLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,23 @@
-import type { Metadata } from 'next'
-import './globals.css'
+import type { Metadata } from "next";
+import "./globals.css";
+import { RouteOverlayProvider } from "./providers/route-overlay";
 
 export const metadata: Metadata = {
-  title: 'v0 App',
-  description: 'Created with v0',
-  generator: 'v0.dev',
-}
+  title: "v0 App",
+  description: "Created with v0",
+  generator: "v0.dev",
+};
 
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang="ko">
+      <body>
+        <RouteOverlayProvider>
+          {children}
+        </RouteOverlayProvider>
+      </body>
     </html>
-  )
+  );
 }

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,12 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+  return (
+    <div className="h-screen grid place-items-center bg-gray-50">
+      <div className="flex flex-col items-center gap-3">
+        <Loader2 className="h-6 w-6 animate-spin" />
+        <p className="text-sm text-gray-600">페이지 준비 중…</p>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import NextImage from "next/image"
 import { Camera, RotateCcw } from "lucide-react"
-
+import { useRouteOverlay } from "./providers/route-overlay";
 
 /**
  * 배경 이미지 블러 설정값
@@ -28,6 +28,7 @@ const BLUR_LEVELS = {
 export default function LandingPage() {
   const hasLoadedOnce = useRef(false)
   const router = useRouter()
+  const { setIsNavigating } = useRouteOverlay();
   const NATURE_BACKGROUND_IMG = "/nature-background.jpg";
 
   // 상태 관리
@@ -55,7 +56,29 @@ export default function LandingPage() {
 }, [])
 
 
-  /**
+// 배경 이미지 로딩 폴백 유지
+useEffect(() => {
+  if (hasLoadedOnce.current || sessionStorage.getItem("bgLoaded") === "true") {
+    setBackgroundLoaded(true)
+    return
+  }
+  const img = new window.Image()
+  img.onload = () => {
+    setBackgroundLoaded(true)
+    hasLoadedOnce.current = true
+    sessionStorage.setItem("bgLoaded", "true")
+  }
+  img.src = NATURE_BACKGROUND_IMG
+}, [])
+
+// ★ 배경이 준비된 '뒤에' 살짝 늦게 오버레이 OFF (페이드 여유)
+useEffect(() => {
+  if (!backgroundLoaded) return
+  const t = setTimeout(() => setIsNavigating(false), 120) // 100~200ms 권장
+  return () => clearTimeout(t)
+}, [backgroundLoaded, setIsNavigating])
+  
+/**
    * 이미지 압축 페이지로 이동
    */
   const handleDownscale = useCallback(() => {

--- a/app/providers/route-overlay.tsx
+++ b/app/providers/route-overlay.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+import { Loader2 } from "lucide-react";
+
+type Ctx = { isNavigating: boolean; setIsNavigating: (v: boolean) => void };
+const NavCtx = createContext<Ctx | null>(null);
+
+export const useRouteOverlay = () => {
+  const ctx = useContext(NavCtx);
+  if (!ctx) throw new Error("useRouteOverlay must be used within <RouteOverlayProvider>");
+  return ctx;
+};
+
+export function RouteOverlayProvider({ children }: { children: ReactNode }) {
+  const [isNavigating, setIsNavigating] = useState(false);
+
+  return (
+    <NavCtx.Provider value={{ isNavigating, setIsNavigating }}>
+      {children}
+      {isNavigating && (
+        <div className="fixed inset-0 z-[100] grid place-items-center bg-white/70 backdrop-blur-sm">
+          <div className="flex flex-col items-center gap-3">
+            <Loader2 className="h-6 w-6 animate-spin" />
+            <p className="text-sm text-gray-700">이동 중…</p>
+          </div>
+        </div>
+      )}
+    </NavCtx.Provider>
+  );
+}

--- a/app/restore/page.tsx
+++ b/app/restore/page.tsx
@@ -9,6 +9,8 @@ import FileUpload from "@/components/file-upload"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { API_BASE_URL, ENDPOINTS, MRS3_MODE_OPTIONS } from "@/lib/constants"
 import { downloadByUrl } from "@/lib/download"
+import { useRouteOverlay } from "../providers/route-overlay";
+
 
 /**
  * 이미지 복원 페이지 (단일/일괄)
@@ -89,10 +91,12 @@ export default function RestorePage() {
     downloadByUrl(resultUrl, "restored-image.png")
   }, [resultUrl])
 
-  /** 홈으로 이동 */
+  const { setIsNavigating } = useRouteOverlay();
+  
   const handleGoHome = useCallback(() => {
-    router.push("/")
-  }, [router])
+    setIsNavigating(true);   // 오버레이 켜기
+    router.push("/");        // 이동 시작
+  }, [router, setIsNavigating]);
 
   // 일괄 복원 핸들러들
   const handleZipSelect = useCallback((file: File) => {
@@ -149,7 +153,7 @@ export default function RestorePage() {
   )?.description || ""
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="h-screen bg-gray-50 py-8 overflow-y-auto no-scrollbar">
       <div className="container mx-auto px-4 max-w-4xl">
         {/* 헤더: 타이틀 중앙 정렬, 뒤로가기 버튼 좌측 고정 */}
         <div className="relative mb-8 mt-16 ">
@@ -171,10 +175,12 @@ export default function RestorePage() {
           </TabsList>
 
           {/* 단일 복원 탭 */}
-          <TabsContent value="single" className="mt-6 space-y-6">
+          <TabsContent value="single" className="mt-6">
             {/* 업로드 영역 */}
-            <div className="flex items-center justify-center h-[40vh]">
-              <div className="w-full max-w-2xl px-4">
+            <div className="space-y-6">
+              
+                <div className="bg-white rounded-lg p-6 shadow-sm">
+                <h2 className="text-xl font-semibold mb-4">.pkg 업로드</h2>
                 <FileUpload onFileSelect={handleFileSelect} accept=".pkg" maxSize={10 * 1024 * 1024} />
 
                 {uploadedFile && (
@@ -188,8 +194,9 @@ export default function RestorePage() {
                     <p className="text-sm text-red-700">{error}</p>
                   </div>
                 )}
-              </div>
-            </div>
+                </div>
+              
+            
 
             {/* 설정 영역: 업로드 전에도 항상 노출 */}
             <div className="bg-white rounded-lg p-6 shadow-sm">
@@ -248,6 +255,7 @@ export default function RestorePage() {
                 </div>
               </div>
             )}
+          </div>
           </TabsContent>
 
           {/* 일괄 복원 탭 */}
@@ -284,6 +292,7 @@ export default function RestorePage() {
                           </SelectItem>
                         ))}
                       </SelectContent>
+                      <p className="text-xs text-gray-500 mt-1">{selectedModeDescription}{mrs3Mode === -1 && " - 처리 시간이 오래 걸릴 수 있습니다."}</p>
                     </Select>
                   </div>
 
@@ -299,6 +308,9 @@ export default function RestorePage() {
                       )}
                     </Button>
                   </div>
+                  {!uploadedFile && (
+                  <p className="text-xs text-gray-500 text-center">pkgs.zip 파일을 업로드해야 복원을 시작할 수 있습니다.</p>
+                )}
                 </div>
               </div>
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,7 +3,7 @@
  * - 프론트 전역에서 재사용되는 API URL, 엔드포인트, 선택 옵션 등을 제공합니다.
  * - 환경 변수: NEXT_PUBLIC_API_BASE_URL (예: http://localhost:8000)
  */
-export const API_BASE_URL =  "https://39dc6ae220df.ngrok-free.app"
+export const API_BASE_URL =  "https://4ccd824b850b.ngrok-free.app"
 
 // 백엔드 엔드포인트
 export const ENDPOINTS = {


### PR DESCRIPTION
feat(app): 글로벌 네비 오버레이 + 로딩 UX 추가, 스크롤/깜빡임 수정

- route overlay 도입: RouteOverlayProvider 추가 및 app/layout.tsx에 전역 적용
  - 전역 오버레이 유지로 라우팅 순간 깜빡임 마스킹
  - useRouteOverlay 훅 제공 (isNavigating, setIsNavigating)
- 페이지 연동:
  - downscale/restore → home 이동 시 setIsNavigating(true) 후 router.push("/")
  - home 도착 시 배경 준비되면 setIsNavigating(false)로 오버레이 해제
- 로딩 화면:
  - (세그먼트 로딩 대응) app/downscale/loading.tsx 추가
- 스크롤/레이아웃 안정화:
  - no-scrollbar 유틸 추가 및 적용
  - body 스크롤 비활성화(overflow: hidden), 페이지 래퍼를 h-screen + overflow-y-auto로 변경
  - 탭 전환 시 좌우 흔들림/스크롤바 점프 감소
- UI/UX 개선:
  - 단일 탭: 중첩 카드 정리, 헤딩 추가, 디자인 통일
  - 안내 문구 조건 수정: 
    - batch는 batchFiles.length 기준으로 메시지 설정
    - single은 업로드+폴리곤 선택 조건과 메시지 일치화
